### PR TITLE
chore(FEC-8845): expose umd named define for requireJS

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,7 @@ module.exports = {
     filename: '[name].js',
     library: ['playkit', 'flash'],
     libraryTarget: 'umd',
+    umdNamedDefine: true,
     devtoolModuleFilenameTemplate: './flash/[resource-path]'
   },
   devtool: 'source-map',


### PR DESCRIPTION
### Description of the Changes

require js requires a named module definition, need to add umdNamedDefine config to webpack.

Also aligned the root import of the library to the player plugins convention.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
