### PR TITLE
fix(FEC-9471): slider progress bar exceeds 100%

### DIFF
--- a/src/flash.js
+++ b/src/flash.js
@@ -303,7 +303,8 @@ class Flash extends FakeEventTarget implements IEngine {
         EventType.SEEKED,
         EventType.ENDED,
         EventType.VIDEO_TRACK_CHANGED,
-        EventType.AUDIO_TRACK_CHANGED
+        EventType.AUDIO_TRACK_CHANGED,
+        EventType.DURATION_CHANGE
       ];
       events.forEach(eventName => {
         this._eventManager.listen(this._api, eventName, (event: FakeEvent) => this.dispatchEvent(event));

--- a/src/flash.js
+++ b/src/flash.js
@@ -45,14 +45,14 @@ class Flash extends FakeEventTarget implements IEngine {
    * @type {Object}
    * @private
    */
-  _config: Object = null;
+  _config: ?Object = null;
 
   /**
    * Promise when load finished
    * @type {Promise<*>}
    * @private
    */
-  _loadPromise: Promise<*> = null;
+  _loadPromise: ?Promise<*> = null;
 
   /**
    * volume value
@@ -420,11 +420,13 @@ class Flash extends FakeEventTarget implements IEngine {
    * @returns {void}
    */
   play(): void {
-    this._loadPromise.then(() => {
-      if (this._api) {
-        this._api.play();
-      }
-    });
+    if (this._loadPromise) {
+      this._loadPromise.then(() => {
+        if (this._api) {
+          this._api.play();
+        }
+      });
+    }
   }
 
   pause(): void {
@@ -800,7 +802,7 @@ class Flash extends FakeEventTarget implements IEngine {
    * @returns {boolean} - Whether the video tag has an attribute of playsinline.
    */
   get playsinline(): boolean {
-    return this._config.playsinline;
+    return this._config ? this._config.playsinline : false;
   }
 
   /**

--- a/src/flashhls-adapter.js
+++ b/src/flashhls-adapter.js
@@ -254,6 +254,7 @@ class FlashHLSAdapter extends FakeEventTarget {
 
   seek(to: number): void {
     if (this._api) {
+      this.currentTime = to;
       this._api.seek(to);
     }
   }

--- a/src/flashhls-adapter.js
+++ b/src/flashhls-adapter.js
@@ -127,7 +127,10 @@ class FlashHLSAdapter extends FakeEventTarget {
       },
       position: (timemetrics: Object) => {
         this.paused = false;
-        this.duration = timemetrics.duration;
+        if (this.duration != timemetrics.duration) {
+          this.duration = timemetrics.duration;
+          this._trigger(EventType.DURATION_CHANGE);
+        }
         this.buffer = timemetrics.buffer;
         this.watched = timemetrics.watched;
         if (this.currentTime != timemetrics.position || this.ended) {


### PR DESCRIPTION
### Description of the Changes

Made the flash behave more similar to HTML5 where updating the currentTime really updates the value of the currentTime and then it changes when playback continues. This is required so that in the "Seeking" event the currentTime will show the target currentTime and not the current one before the seek

solves FEC-9471
### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
