### PR TITLE
fix(FEC-9603): timing issue after reinitialise the flash api

### DIFF
--- a/src/flashhls-adapter.js
+++ b/src/flashhls-adapter.js
@@ -140,7 +140,9 @@ class FlashHLSAdapter extends FakeEventTarget {
         if (this._api && this._config.debug) {
           this._api.playerSetLogDebug2(true);
         }
-        if (this._apiLoadResolve) this._apiLoadResolve();
+        if (this._apiLoadResolve) {
+          this._apiLoadResolve();
+        }
       },
       levelLoaded: loadmetrics => {
         if (!this._loadReported) {


### PR DESCRIPTION
### Description of the Changes

Issue: load occur on attach, need to wait until api is ready.
Solution: reset the promises that indicate when api is ready and initialise on attach.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
