### PR TITLE
chore: the travis tag wasn't correct for Jenkins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,9 @@ jobs:
             tags: true
             branch: master
       after_deploy:
+        - currentVersion=$(npx -c 'echo "$npm_package_version"')
         - chmod +x ./scripts/after_deploy.sh
-        - ./scripts/after_deploy.sh "flash" "$TRAVIS_TAG" "$JENKINS_TAG_TOKEN"
+        - ./scripts/after_deploy.sh "flash" "$currentVersion" "$JENKINS_TAG_TOKEN"
     # publish canary package if on master
     - stage: Release canary
       if: (branch = master) AND (type != pull_request) AND commit_message !~ /^chore\(release\)/


### PR DESCRIPTION
### Description of the Changes

issue: the travis tag wasn't correct for Jenkins( includes vx.x.x. instead x.x.x).
solution: get the version from package.json

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
