### PR TITLE
feat(FEC-10347): expose kaltura player as a global variable instead of UMD

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,6 @@ module.exports = {
     path: __dirname + '/dist',
     filename: '[name].js',
     library: ['playkit', 'flash'],
-    libraryTarget: 'umd',
     umdNamedDefine: true,
     devtoolModuleFilenameTemplate: './flash/[resource-path]'
   },
@@ -51,11 +50,6 @@ module.exports = {
     modules: [path.resolve(__dirname, 'src'), 'node_modules']
   },
   externals: {
-    '@playkit-js/playkit-js': {
-      commonjs: '@playkit-js/playkit-js',
-      commonjs2: '@playkit-js/playkit-js',
-      amd: 'playkit-js',
-      root: ['KalturaPlayer', 'core']
-    }
+    '@playkit-js/playkit-js': ['KalturaPlayer', 'core']
   }
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,6 @@ module.exports = {
     path: __dirname + '/dist',
     filename: '[name].js',
     library: ['playkit', 'flash'],
-    umdNamedDefine: true,
     devtoolModuleFilenameTemplate: './flash/[resource-path]'
   },
   devtool: 'source-map',


### PR DESCRIPTION
### Description of the Changes

set `libraryTarget:'var'` as default.
Change the externals to use the root only.

BREAKING CHANGE: This package is not UMD anymore

Solves FEC-10347

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
